### PR TITLE
[add] kafka, mongodb, payment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
     depends_on:
       - redis
       - kafka
+      - mongo
     env_file: .env
-    networks:
-      - real-estate-network
 
   redis:
     image: redis:alpine
@@ -19,33 +18,35 @@ services:
     hostname: real-estate-redis
     ports:
       - "6379:6379"
-    networks:
-      - real-estate-network
 
   zookeeper:
-    image: harin1212/zookeeper
+    image: confluentinc/cp-zookeeper:latest
     container_name: zookeeper
     ports:
       - "2181:2181"
-    networks:
-      - real-estate-network
 
   kafka:
-    image: harin1212/kafka
-    container_name: localhost
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_CREATE_TOPICS: "realestate:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
-    networks:
-      - real-estate-network
 
-networks:
-  real-estate-network:
-    driver: bridge
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: test
+      MONGO_INITDB_ROOT_PASSWORD: test
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     container_name: zookeeper
     ports:
       - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181  # 추가된 부분
 
   kafka:
     image: confluentinc/cp-kafka:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,51 @@
-# compose 파일 버전
 version: '3'
 services:
+  web:
+    image: harin1212/real-estate-backend:latest
+    container_name: real-estate-backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+      - kafka
+    env_file: .env
+    networks:
+      - real-estate-network
+
   redis:
-    image: redis:latest
-    container_name: redis
+    image: redis:alpine
+    container_name: real-estate-redis
+    command: redis-server --port 6379
+    hostname: real-estate-redis
     ports:
       - "6379:6379"
-      # 서비스 명
+    networks:
+      - real-estate-network
+
   zookeeper:
-    # 사용할 이미지
-    image: wurstmeister/zookeeper
-    # 컨테이너명 설정
+    image: harin1212/zookeeper
     container_name: zookeeper
-    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
     ports:
       - "2181:2181"
-  # 서비스 명
+    networks:
+      - real-estate-network
+
   kafka:
-    # 사용할 이미지
-    image: wurstmeister/kafka
-    # 컨테이너명 설정
-    container_name: kafka
-    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+    image: harin1212/kafka
+    container_name: localhost
     ports:
       - "9092:9092"
-    # 환경 변수 설정
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_CREATE_TOPICS: "realestate:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    # 볼륨 설정
     volumes:
-      - /var/run/docker.sock
-    # 의존 관계 설정
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
+    networks:
+      - real-estate-network
+
+networks:
+  real-estate-network:
+    driver: bridge

--- a/src/main/java/com/realEstate/realEstate/controller/PaymentController.java
+++ b/src/main/java/com/realEstate/realEstate/controller/PaymentController.java
@@ -4,20 +4,29 @@ import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.IamportResponse;
 import com.siot.IamportRestClient.response.Payment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 
-@Controller
+@RestController
 public class PaymentController {
-    private final IamportClient iamportClient;
 
-    public PaymentController() {
-        this.iamportClient = new IamportClient("REST_API_KEY",
-                "REST_API_SECRET");
+    @Value("${iamport.key}")
+    private String restApiKey;
+    @Value("${iamport.secret}")
+    private String restApiSecret;
+
+    private IamportClient iamportClient;
+
+    @PostConstruct
+    public void init() {
+        this.iamportClient = new IamportClient(restApiKey, restApiSecret);
     }
 
     @ResponseBody

--- a/src/main/java/com/realEstate/realEstate/util/jwt/JwtService.java
+++ b/src/main/java/com/realEstate/realEstate/util/jwt/JwtService.java
@@ -29,7 +29,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 @Slf4j
 public class JwtService {
 
-    @Value("${jwt.secretKey}")
+    @Value("${jwt.secret-key}")
     private String secretKey;
 
     @Value("${jwt.access.expiration}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,26 +4,24 @@ logging:
       springframework:
         web:
           socket: DEBUG
+
 spring:
   data:
     mongodb:
       database: realEstate
-      host: localhost
+      host: mongo  # Docker Compose 환경의 서비스 이름으로 변경
       port: 27017
       authentication-database: admin
       username: test
       password: test
   redis:
-    host: localhost
+    host: real-estate-redis
     port: 6379
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: 'jdbc:mysql://database-1.cdic8iso881z.ap-northeast-2.rds.amazonaws.com :3306/realEstate?serverTimezone=Asia/Seoul&characterEncoding=UTF-8'
+    url: 'jdbc:mysql://database-1.cdic8iso881z.ap-northeast-2.rds.amazonaws.com:3306/realEstate?serverTimezone=Asia/Seoul&characterEncoding=UTF-8'
     username: ${AWS.USERNAME}
     password: ${AWS.PASSWORD}
-#    url: 'jdbc:mysql://localhost:3306/realEstate'
-#    username: root
-#    password: 1107jkk!
   jpa:
     hibernate:
       ddl-auto: update
@@ -61,26 +59,26 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
           naver:
-            authorization_uri: https://nid.naver.com/oauth2.0/authorize
-            token_uri: https://nid.naver.com/oauth2.0/token
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
-            user_name_attribute: response
+            user-name-attribute: response
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: kafka:9092  # Docker Compose 환경의 서비스 이름으로 변경
     template:
       default-topic: realestate
+
 jwt:
   secret-key: fast-campus.simple_sns_2022_secret_key
   # 30 days
-  token.expired-time-ms: 2592000000
-  secretKey: fast-campus.simple_sns_2022_secret_key
+  token:
+    expired-time-ms: 2592000000
   refresh:
     expiration: 604800000
     header: Refresh-Token
   access:
     header: Authorization
     expiration: 604800000
-
 
 cloud:
   aws:
@@ -95,18 +93,20 @@ cloud:
     stack:
       auto: false
 
-
 chatgpt:
   api-key: ${CHATGPT_API_KEY}
   model: text-davinci-003
+
 openai:
   url:
     model: https://api.openai.com/v1/models
     model-list: https://api.openai.com/v1/models/
     legacy-prompt: https://api.openai.com/v1/completions
     prompt: https://api.openai.com/v1/chat/completions
+
 image:
-  save_path : ./images
+  save_path: ./images
+
 api:
   building-key: ${GET_BUILDING_API_KEY}
   land-key: ${GET_LAND_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,3 +110,7 @@ image:
 api:
   building-key: ${GET_BUILDING_API_KEY}
   land-key: ${GET_LAND_API_KEY}
+
+iamport:
+  key: ${IAM_PORT_KEY}
+  secret: ${IAM_PORT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ spring:
       default-topic: realestate
 
 jwt:
-  secret-key: fast-campus.simple_sns_2022_secret_key
+  secret-key: ${JWT_SECRET}
   # 30 days
   token:
     expired-time-ms: 2592000000


### PR DESCRIPTION
## ✅ 구현 기능
도커 컴포즈에 kafka, mogodb 추가
Iam 포트 결제 컨트롤러 구현

## 🔎 작업 내용
배포 서버에서 통신을 위해 docker compose에 kafka, mogodb 설정 추가했습니다.
Iam 포트 백엔드 연동완료했습니다.
KG이니시스 테스트용 API 키 사용했습니다.

## 🔧 TODO
- 프론트랑 결제 시스템 테스트
- kafka, mogodb 연결 설정 테스트

## ➕ 이슈 링크
#63 
